### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Django>=2.1,<2.2
 mongoengine>=0.15
-djangorestframework >=3.8
+djangorestframework==3.9.3


### PR DESCRIPTION
Версия зафиксирована потому, что в djangorestframework > 3.9.3 удалили обратную совместимость со вторым питоном, в частности вырезали `rest_framework.compat.unicode_to_repr` которую использует эта библиотека в текущей версии